### PR TITLE
Recipe section cutting off top of recipe container #38

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -45,6 +45,7 @@ h1 {
   overflow: scroll;
   font-weight: bolder;
   /* background-color: white; */
+  padding-top: 2em;
 }
 
 .recipe-card {


### PR DESCRIPTION
Resolution for #38 

Easy-fix, I did notice that there's some further cut off in the recipe titles causing an overflow of the text even with the scrolling. Would it be alright for me to create an issue on this?

![image](https://github.com/joh-ann/whats-cookin/assets/79110517/141b62ce-8ed6-49a2-8d8c-e5c1eefb476d)


Let me know your thoughts and thanks!