### PR TITLE
Display recipe cards at the top of the section

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -38,7 +38,7 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   gap: 50px;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   height: 750px;
   width: 80%;


### PR DESCRIPTION
## Changes:
This changes a line in CSS so that the recipe cards show up at the top rather than in the center of the page.

## Checklist:
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Is there any unexpected behaviour?

## Unexpected behaviour:
N/A